### PR TITLE
Fix MacOS build issue

### DIFF
--- a/include/f1x/aasdk/Error/Error.hpp
+++ b/include/f1x/aasdk/Error/Error.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <stdexcept>
+#include <string>
 #include <f1x/aasdk/Error/ErrorCode.hpp>
 
 namespace f1x


### PR DESCRIPTION
```
In file included from /Users/duxet/git/aasdk/src/Channel/ServiceChannel.cpp:19:
In file included from /Users/duxet/git/aasdk/include/f1x/aasdk/IO/PromiseLink.hpp:23:
/Users/duxet/git/aasdk/include/f1x/aasdk/Error/Error.hpp:47:17: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    std::string message_;
                ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iosfwd:193:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
1 error generated.
```