### PR TITLE
Fix remaining MacOS build issues

### DIFF
--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -16,6 +16,7 @@
 *  along with aasdk. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <string>
 #include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>


### PR DESCRIPTION
With these changes project will compile successfully on MacOS by adding `-DOPENSSL_ROOT_DIR=$(brew --prefix openssl)` parameter to cmake.

I had to add `set(Protobuf_USE_STATIC_LIBS ON)` to fix issue with:
```
$ bin/autoapp
[libprotobuf ERROR google/protobuf/descriptor_database.cc:58] File already exists in database: AVMediaAckIndicationMessage.proto
[libprotobuf FATAL google/protobuf/descriptor.cc:1394] CHECK failed: generated_database_->Add(encoded_file_descriptor, size):
libc++abi.dylib: terminating with uncaught exception of type google::protobuf::FatalException: CHECK failed: generated_database_->Add(encoded_file_descriptor, size):
```