### PR TITLE
Bug fixes for gcc 7.2.0 and libusb

### DIFF
--- a/src/Transport/SSLWrapper.cpp
+++ b/src/Transport/SSLWrapper.cpp
@@ -52,7 +52,7 @@ SSLWrapper::~SSLWrapper()
 
 X509* SSLWrapper::readCertificate(const std::string& certificate)
 {
-    auto bio = BIO_new_mem_buf(certificate.c_str(), certificate.size());
+    auto bio = BIO_new_mem_buf((void *)certificate.c_str(), certificate.size());
     X509* x509Certificate = PEM_read_bio_X509_AUX(bio, nullptr, nullptr, nullptr);
     BIO_free(bio);
 
@@ -61,7 +61,7 @@ X509* SSLWrapper::readCertificate(const std::string& certificate)
 
 EVP_PKEY* SSLWrapper::readPrivateKey(const std::string& privateKey)
 {
-    auto bio = BIO_new_mem_buf(privateKey.c_str(), privateKey.size());
+    auto bio = BIO_new_mem_buf((void *)privateKey.c_str(), privateKey.size());
     auto result = PEM_read_bio_PrivateKey (bio, nullptr, nullptr, nullptr);
     BIO_free(bio);
 

--- a/src/USB/USBHub.cpp
+++ b/src/USB/USBHub.cpp
@@ -21,6 +21,7 @@
 #include <f1x/aasdk/USB/USBHub.hpp>
 #include <f1x/aasdk/USB/AccessoryModeQueryChain.hpp>
 #include <f1x/aasdk/Error/Error.hpp>
+#include <libusb.h>
 
 namespace f1x
 {
@@ -50,7 +51,7 @@ void USBHub::start(Promise::Pointer promise)
         if(self_ == nullptr)
         {
             self_ = this->shared_from_this();
-            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
+            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_ENUMERATE, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                                  LIBUSB_HOTPLUG_MATCH_ANY, &USBHub::hotplugEventsHandler, reinterpret_cast<void*>(this));
         }
     });


### PR DESCRIPTION
Fixed bug that causes gcc 7.2.0 to throw an error for void* typecasting
Fixed bug that causes 'LIBUSB_HOTPLUG_NO_FLAGS' not delacred error. 
Fixes issues stated in #10 