### PR TITLE
Feature/performance improvements

### DIFF
--- a/include/f1x/aasdk/IO/IOContextWrapper.hpp
+++ b/include/f1x/aasdk/IO/IOContextWrapper.hpp
@@ -28,11 +28,9 @@ namespace aasdk
 namespace io
 {
 
-class IOContextWrapper: boost::noncopyable
+class IOContextWrapper
 {
 public:
-    typedef std::shared_ptr<IOContextWrapper> Pointer;
-
     IOContextWrapper();
     explicit IOContextWrapper(boost::asio::io_service& ioService);
     explicit IOContextWrapper(boost::asio::io_service::strand& strand);

--- a/include/f1x/aasdk/IO/Promise.hpp
+++ b/include/f1x/aasdk/IO/Promise.hpp
@@ -51,13 +51,13 @@ public:
     }
 
     Promise(boost::asio::io_service& ioService)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(ioService))
+        : ioContextWrapper_(ioService)
     {
 
     }
 
     Promise(boost::asio::io_service::strand& strand)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(strand))
+        : ioContextWrapper_(strand)
     {
 
     }
@@ -76,12 +76,11 @@ public:
 
         if(resolveHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([argument = std::move(argument), resolveHandler = std::move(resolveHandler_)]() mutable {
+            ioContextWrapper_.post([argument = std::move(argument), resolveHandler = std::move(resolveHandler_)]() mutable {
                 (*resolveHandler)(std::move(argument));
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         rejectHandler_.reset();
     }
@@ -92,12 +91,11 @@ public:
 
         if(rejectHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([error = std::move(error), rejectHandler = std::move(rejectHandler_)]() mutable {
+            ioContextWrapper_.post([error = std::move(error), rejectHandler = std::move(rejectHandler_)]() mutable {
                 (*rejectHandler)(std::move(error));
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         resolveHandler_.reset();
     }
@@ -105,12 +103,12 @@ public:
 private:
     bool isPending() const
     {
-        return ioContextWrapper_ != nullptr && ioContextWrapper_->isActive();
+        return ioContextWrapper_.isActive();
     }
 
     std::shared_ptr<ResolveHandler> resolveHandler_;
     std::shared_ptr<RejectHandler> rejectHandler_;
-    IOContextWrapper::Pointer ioContextWrapper_;
+    IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
 };
 
@@ -134,13 +132,13 @@ public:
     }
 
     Promise(boost::asio::io_service& ioService)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(ioService))
+        : ioContextWrapper_(ioService)
     {
 
     }
 
     Promise(boost::asio::io_service::strand& strand)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(strand))
+        : ioContextWrapper_(strand)
     {
 
     }
@@ -159,12 +157,11 @@ public:
 
         if(resolveHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([resolveHandler = std::move(resolveHandler_)]() mutable {
+            ioContextWrapper_.post([resolveHandler = std::move(resolveHandler_)]() mutable {
                 (*resolveHandler)();
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         rejectHandler_.reset();
     }
@@ -175,12 +172,11 @@ public:
 
         if(rejectHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([error = std::move(error), rejectHandler = std::move(rejectHandler_)]() mutable {
+            ioContextWrapper_.post([error = std::move(error), rejectHandler = std::move(rejectHandler_)]() mutable {
                 (*rejectHandler)(std::move(error));
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         resolveHandler_.reset();
     }
@@ -188,12 +184,12 @@ public:
 private:
     bool isPending() const
     {
-        return ioContextWrapper_ != nullptr && ioContextWrapper_->isActive();
+        return ioContextWrapper_.isActive();
     }
 
     std::shared_ptr<ResolveHandler> resolveHandler_;
     std::shared_ptr<RejectHandler> rejectHandler_;
-    IOContextWrapper::Pointer ioContextWrapper_;
+    IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
 };
 
@@ -216,13 +212,13 @@ public:
     }
 
     Promise(boost::asio::io_service& ioService)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(ioService))
+        : ioContextWrapper_(ioService)
     {
 
     }
 
     Promise(boost::asio::io_service::strand& strand)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(strand))
+        : ioContextWrapper_(strand)
     {
 
     }
@@ -241,12 +237,11 @@ public:
 
         if(resolveHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([resolveHandler = std::move(resolveHandler_)]() mutable {
+            ioContextWrapper_.post([resolveHandler = std::move(resolveHandler_)]() mutable {
                 (*resolveHandler)();
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         rejectHandler_.reset();
     }
@@ -257,12 +252,11 @@ public:
 
         if(rejectHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([rejectHandler = std::move(rejectHandler_)]() mutable {
+            ioContextWrapper_.post([rejectHandler = std::move(rejectHandler_)]() mutable {
                 (*rejectHandler)();
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         resolveHandler_.reset();
     }
@@ -270,12 +264,12 @@ public:
 private:
     bool isPending() const
     {
-        return ioContextWrapper_ != nullptr && ioContextWrapper_->isActive();
+        return ioContextWrapper_.isActive();
     }
 
     std::shared_ptr<ResolveHandler> resolveHandler_;
     std::shared_ptr<RejectHandler> rejectHandler_;
-    IOContextWrapper::Pointer ioContextWrapper_;
+    IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
 };
 
@@ -299,13 +293,13 @@ public:
     }
 
     Promise(boost::asio::io_service& ioService)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(ioService))
+        : ioContextWrapper_(ioService)
     {
 
     }
 
     Promise(boost::asio::io_service::strand& strand)
-        : ioContextWrapper_(std::make_shared<IOContextWrapper>(strand))
+        : ioContextWrapper_(strand)
     {
 
     }
@@ -324,12 +318,11 @@ public:
 
         if(resolveHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([argument = std::move(argument), resolveHandler = std::move(resolveHandler_)]() mutable {
+            ioContextWrapper_.post([argument = std::move(argument), resolveHandler = std::move(resolveHandler_)]() mutable {
                 (*resolveHandler)(std::move(argument));
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         rejectHandler_.reset();
     }
@@ -340,12 +333,11 @@ public:
 
         if(rejectHandler_ != nullptr && this->isPending())
         {
-            ioContextWrapper_->post([rejectHandler = std::move(rejectHandler_)]() mutable {
+            ioContextWrapper_.post([rejectHandler = std::move(rejectHandler_)]() mutable {
                 (*rejectHandler)();
             });
         }
 
-        ioContextWrapper_->reset();
         ioContextWrapper_.reset();
         resolveHandler_.reset();
     }
@@ -353,12 +345,12 @@ public:
 private:
     bool isPending() const
     {
-        return ioContextWrapper_ != nullptr && ioContextWrapper_->isActive();
+        return ioContextWrapper_.isActive();
     }
 
     std::shared_ptr<ResolveHandler> resolveHandler_;
     std::shared_ptr<RejectHandler> rejectHandler_;
-    IOContextWrapper::Pointer ioContextWrapper_;
+    IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
 };
 

--- a/src/Transport/DataSink.cpp
+++ b/src/Transport/DataSink.cpp
@@ -47,7 +47,7 @@ void DataSink::commit(common::Data::size_type size)
         throw error::Error(error::ErrorCode::DATA_SINK_COMMIT_OVERFLOW);
     }
 
-    data_.resize(data_.size() - (cChunkSize - size));
+    data_.erase_end((cChunkSize - size));
 }
 
 common::Data::size_type DataSink::getAvailableSize()
@@ -64,7 +64,7 @@ common::Data DataSink::consume(common::Data::size_type size)
 
     common::Data data;
     common::copy(data, common::DataConstBuffer(&data_[0], size));
-    data_.erase(data_.begin(), data_.begin() + size);
+    data_.erase_begin(size);
 
     return data;
 }

--- a/src/Transport/DataSink.cpp
+++ b/src/Transport/DataSink.cpp
@@ -37,7 +37,8 @@ common::DataBuffer DataSink::fill()
     const auto offset = data_.size();
     data_.resize(data_.size() + cChunkSize);
 
-    return common::DataBuffer(&data_[offset], cChunkSize);
+    auto ptr = data_.is_linearized() ? &data_[offset] : data_.linearize() + offset;
+    return common::DataBuffer(ptr, cChunkSize);
 }
 
 void DataSink::commit(common::Data::size_type size)
@@ -62,8 +63,8 @@ common::Data DataSink::consume(common::Data::size_type size)
         throw error::Error(error::ErrorCode::DATA_SINK_CONSUME_UNDERFLOW);
     }
 
-    common::Data data;
-    common::copy(data, common::DataConstBuffer(&data_[0], size));
+    common::Data data(size, 0);
+    std::copy(data_.begin(), data_.begin() + size, data.begin());
     data_.erase_begin(size);
 
     return data;

--- a/src/Transport/DataSink.cpp
+++ b/src/Transport/DataSink.cpp
@@ -35,7 +35,7 @@ DataSink::DataSink()
 common::DataBuffer DataSink::fill()
 {
     const auto offset = data_.size();
-    data_.insert(data_.end(), cChunkSize, 0);
+    data_.resize(data_.size() + cChunkSize);
 
     return common::DataBuffer(&data_[offset], cChunkSize);
 }

--- a/src/Transport/DataSink.cpp
+++ b/src/Transport/DataSink.cpp
@@ -35,7 +35,7 @@ DataSink::DataSink()
 common::DataBuffer DataSink::fill()
 {
     const auto offset = data_.size();
-    data_.resize(data_.size() + cChunkSize);
+    data_.insert(data_.end(), cChunkSize, 0);
 
     return common::DataBuffer(&data_[offset], cChunkSize);
 }


### PR DESCRIPTION
IOContextWrapper does not need to be used as shared_ptr.
Improved usage of circular_buffer (used methods with constant complexity).