### PR TITLE
[proto] correct spelling for angle

### DIFF
--- a/aasdk_proto/SteeringWheelData.proto
+++ b/aasdk_proto/SteeringWheelData.proto
@@ -22,6 +22,6 @@ package f1x.aasdk.proto.data;
 
 message SteeringWheel
 {
-    int32 steering_angel = 1;
+    int32 steering_angle = 1;
     int32 wheel_speed = 2;
 }


### PR DESCRIPTION
The steering_angle variable was misspelled. Correct the spelling.