### PR TITLE
factor out boost:noncopyable and simplify googletest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 # Add any directories, files, or patterns you don't want to be tracked by version control
-lib/
-bin/
+._*
+.vscode
+build
+.idea
+cmake-build-*
 CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
-project(aasdk CXX)
+project(aasdk LANGUAGES CXX)
+
+option(AASDK_TEST "Build Unit Test Cases" OFF)
+option(AASDK_CODE_COVERAGE "Build with Code Coverage" OFF)
 
 set(base_directory ${CMAKE_CURRENT_SOURCE_DIR})
 set(sources_directory ${base_directory}/src)
@@ -7,17 +10,13 @@ set(sources_directory ${base_directory}/src)
 set(include_directory ${base_directory}/include)
 set(include_ut_directory ${base_directory}/include_ut)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${base_directory}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${base_directory}/lib)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${base_directory}/bin)
-set(EXECUTABLE_OUTPUT_PATH ${base_directory}/bin)
-
 SET(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake_modules/")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -fPIC -Wall -pedantic")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "-g -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -Wall -pedantic")
 
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
@@ -28,10 +27,6 @@ add_definitions(-DBOOST_ALL_DYN_LINK)
 if(WIN32)
     set(WINSOCK2_LIBRARIES "ws2_32")
 endif(WIN32)
-
-if(AASDK_TEST)
-    include(ExternalGtest)
-endif(AASDK_TEST)
 
 add_subdirectory(aasdk_proto)
 
@@ -66,26 +61,42 @@ add_library(aasdk SHARED
 add_dependencies(aasdk aasdk_proto)
 target_link_libraries(aasdk
                         aasdk_proto
-                        ${Boost_LIBRARIES}
+                        Boost::system
+                        Boost::log
+                        protobuf::libprotobuf-lite
+                        OpenSSL::SSL
+                        OpenSSL::Crypto
                         ${LIBUSB_1_LIBRARIES}
-                        ${PROTOBUF_LIBRARIES}
-                        ${OPENSSL_LIBRARIES}
                         ${WINSOCK2_LIBRARIES})
 
+install(TARGETS aasdk LIBRARY DESTINATION lib)
+install(DIRECTORY include/f1x/aasdk DESTINATION include/f1x)
+
 if(AASDK_TEST)
+    include(ExternalGtest)
     add_executable(aasdk_ut
                     ${tests_source_files}
                     ${tests_include_files})
 
-    add_dependencies(aasdk_ut aasdk)
+    add_dependencies(aasdk_ut aasdk googletest)
+
+    target_include_directories(aasdk_ut PUBLIC ${EXT_STAGING_DIR}/include)
+    target_link_directories(aasdk_ut PUBLIC ${EXT_STAGING_DIR}/lib)
     target_link_libraries(aasdk_ut
                             aasdk
-                            ${GMOCK_LIBRARY_PATH}
-                            ${GTEST_LIBRARY_PATH})
+                            Boost::unit_test_framework
+                            gmock${GTEST_DEBUG_POSTFIX}
+                            gmock_main${GTEST_DEBUG_POSTFIX}
+                            gtest${GTEST_DEBUG_POSTFIX}
+                            gtest_main${GTEST_DEBUG_POSTFIX}
+                            Threads::Threads)
 
     if(AASDK_CODE_COVERAGE)
         include(CodeCoverage)
         append_coverage_compiler_flags()
         setup_target_for_coverage(NAME aasdk_coverage EXECUTABLE aasdk_ut DEPENDENCIES aasdk_ut)
     endif(AASDK_CODE_COVERAGE)
+
+    install(TARGETS aasdk_ut LIBRARY DESTINATION share/aasdk)
+    
 endif(AASDK_TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5.1)
-project(aasdk LANGUAGES CXX)
+cmake_minimum_required(VERSION 3.10.6)
+project(aasdk VERSION 0.1.0 LANGUAGES CXX)
 
 option(AASDK_TEST "Build Unit Test Cases" OFF)
 option(AASDK_CODE_COVERAGE "Build with Code Coverage" OFF)
@@ -69,7 +69,10 @@ target_link_libraries(aasdk
                         ${LIBUSB_1_LIBRARIES}
                         ${WINSOCK2_LIBRARIES})
 
-install(TARGETS aasdk LIBRARY DESTINATION lib)
+set_target_properties(aasdk PROPERTIES
+    VERSION "${PROJECT_VERSION}")
+
+install(TARGETS aasdk LIBRARY ARCHIVE DESTINATION lib)
 install(DIRECTORY include/f1x/aasdk DESTINATION include/f1x)
 
 if(AASDK_TEST)

--- a/aasdk_proto/CMakeLists.txt
+++ b/aasdk_proto/CMakeLists.txt
@@ -3,7 +3,15 @@ find_package(Protobuf REQUIRED)
 include_directories(${PROTOBUF_INCLUDE_DIR})
 
 file(GLOB_RECURSE proto_files ${CMAKE_CURRENT_SOURCE_DIR}/*.proto)
+
 protobuf_generate_cpp(proto_sources proto_headers ${proto_files})
+
 add_library(aasdk_proto SHARED ${proto_headers} ${proto_sources})
+
 target_link_libraries(aasdk_proto ${PROTOBUF_LIBRARIES})
 
+set_target_properties(aasdk_proto PROPERTIES PUBLIC_HEADER "${proto_headers}")
+
+install(TARGETS aasdk_proto
+    LIBRARY DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/aasdk_proto)

--- a/aasdk_proto/CMakeLists.txt
+++ b/aasdk_proto/CMakeLists.txt
@@ -10,7 +10,9 @@ add_library(aasdk_proto SHARED ${proto_headers} ${proto_sources})
 
 target_link_libraries(aasdk_proto ${PROTOBUF_LIBRARIES})
 
-set_target_properties(aasdk_proto PROPERTIES PUBLIC_HEADER "${proto_headers}")
+set_target_properties(aasdk_proto PROPERTIES
+    VERSION "${PROJECT_VERSION}"
+    PUBLIC_HEADER "${proto_headers}")
 
 install(TARGETS aasdk_proto
     LIBRARY DESTINATION lib

--- a/cmake_modules/ExternalGtest.cmake
+++ b/cmake_modules/ExternalGtest.cmake
@@ -1,48 +1,23 @@
 find_package(Threads REQUIRED)
 
+set(EXT_STAGING_DIR ${CMAKE_CURRENT_BINARY_DIR}/staging${CMAKE_INSTALL_PREFIX})
+
 include(ExternalProject)
 ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  UPDATE_COMMAND ""
-  INSTALL_COMMAND ""
-  LOG_DOWNLOAD ON
-  LOG_CONFIGURE ON
-  LOG_BUILD ON)
+  GIT_TAG master
+  GIT_SHALLOW ON
+  CMAKE_ARGS
+    -D CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -D CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -D CMAKE_STAGING_PREFIX=${EXT_STAGING_DIR}
+    -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -D CMAKE_VERBOSE_MAKEFILE=ON
+)
 
-ExternalProject_Get_Property(googletest source_dir)
-set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include)
-set(GMOCK_INCLUDE_DIRS ${source_dir}/googlemock/include)
-
-ExternalProject_Get_Property(googletest binary_dir)
-set(GTEST_LIBRARY_PATH ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
-set(GTEST_LIBRARY gtest)
-add_library(${GTEST_LIBRARY} UNKNOWN IMPORTED)
-set_target_properties(${GTEST_LIBRARY} PROPERTIES
-  IMPORTED_LOCATION ${GTEST_LIBRARY_PATH}
-  IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(${GTEST_LIBRARY} googletest)
-
-set(GTEST_MAIN_LIBRARY_PATH ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main.a)
-set(GTEST_MAIN_LIBRARY gtest_main)
-add_library(${GTEST_MAIN_LIBRARY} UNKNOWN IMPORTED)
-set_target_properties(${GTEST_MAIN_LIBRARY} PROPERTIES
-  IMPORTED_LOCATION ${GTEST_MAIN_LIBRARY_PATH}
-  IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(${GTEST_MAIN_LIBRARY} googletest)
-
-set(GMOCK_LIBRARY_PATH ${binary_dir}/googlemock/${CMAKE_FIND_LIBRARY_PREFIXES}gmock.a)
-set(GMOCK_LIBRARY gmock)
-add_library(${GMOCK_LIBRARY} UNKNOWN IMPORTED)
-set_target_properties(${GMOCK_LIBRARY} PROPERTIES
-  IMPORTED_LOCATION ${GMOCK_LIBRARY_PATH}
-  IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(${GMOCK_LIBRARY} googletest)
-
-set(GMOCK_MAIN_LIBRARY_PATH ${binary_dir}/googlemock/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main.a)
-set(GMOCK_MAIN_LIBRARY gmock_main)
-add_library(${GMOCK_MAIN_LIBRARY} UNKNOWN IMPORTED)
-set_target_properties(${GMOCK_MAIN_LIBRARY} PROPERTIES
-  IMPORTED_LOCATION ${GMOCK_MAIN_LIBRARY_PATH}
-  IMPORTED_LINK_INTERFACE_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
-add_dependencies(${GMOCK_MAIN_LIBRARY} ${GTEST_LIBRARY})
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+    set(GTEST_DEBUG_POSTFIX d)
+else()
+    set(GTEST_DEBUG_POSTFIX)
+endif()

--- a/include/f1x/aasdk/Channel/AV/IAudioServiceChannelEventHandler.hpp
+++ b/include/f1x/aasdk/Channel/AV/IAudioServiceChannelEventHandler.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <aasdk_proto/AVChannelSetupRequestMessage.pb.h>
 #include <aasdk_proto/AVChannelStartIndicationMessage.pb.h>
 #include <aasdk_proto/AVChannelStopIndicationMessage.pb.h>

--- a/include/f1x/aasdk/Channel/Control/ControlServiceChannel.hpp
+++ b/include/f1x/aasdk/Channel/Control/ControlServiceChannel.hpp
@@ -46,7 +46,7 @@ public:
     void sendAudioFocusResponse(const proto::messages::AudioFocusResponse& response, SendPromise::Pointer promise) override;
     void sendShutdownRequest(const proto::messages::ShutdownRequest& request, SendPromise::Pointer promise) override;
     void sendShutdownResponse(const proto::messages::ShutdownResponse& response, SendPromise::Pointer promise) override;
-    void sendNavigationFocusResponse(const proto::messages::NavigationFocusResponse& respons, SendPromise::Pointer promisee) override;
+    void sendNavigationFocusResponse(const proto::messages::NavigationFocusResponse&response, SendPromise::Pointer promise) override;
     void sendPingRequest(const proto::messages::PingRequest& request, SendPromise::Pointer promise) override;
 
 private:

--- a/include/f1x/aasdk/Channel/Input/IInputServiceChannelEventHandler.hpp
+++ b/include/f1x/aasdk/Channel/Input/IInputServiceChannelEventHandler.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <aasdk_proto/ChannelOpenRequestMessage.pb.h>
 #include <aasdk_proto/BindingRequestMessage.pb.h>
 

--- a/include/f1x/aasdk/Common/Data.hpp
+++ b/include/f1x/aasdk/Common/Data.hpp
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <string>
+#include <cstring>
 #include <cstddef>
 #include <cstdint>
 

--- a/include/f1x/aasdk/Common/Data.hpp
+++ b/include/f1x/aasdk/Common/Data.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
 
 namespace f1x
 {

--- a/include/f1x/aasdk/Error/Error.hpp
+++ b/include/f1x/aasdk/Error/Error.hpp
@@ -33,7 +33,7 @@ class Error: public std::exception
 {
 public:
     Error();
-    Error(ErrorCode code, uint32_t nativeCode = 0);
+    explicit Error(ErrorCode code, uint32_t nativeCode = 0);
 
     ErrorCode getCode() const;
     uint32_t getNativeCode() const;

--- a/include/f1x/aasdk/Error/ErrorCode.hpp
+++ b/include/f1x/aasdk/Error/ErrorCode.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace f1x
 {

--- a/include/f1x/aasdk/IO/IOContextWrapper.hpp
+++ b/include/f1x/aasdk/IO/IOContextWrapper.hpp
@@ -40,11 +40,11 @@ public:
     {
         if(ioService_ != nullptr)
         {
-            ioService_->post(std::move(handler));
+            ioService_->post(std::forward<CompletionHandlerType>(handler));
         }
         else if(strand_ != nullptr)
         {
-            strand_->post(std::move(handler));
+            strand_->post(std::forward<CompletionHandlerType>(handler));
         }
     }
 
@@ -53,11 +53,11 @@ public:
     {
         if(ioService_ != nullptr)
         {
-            ioService_->dispatch(std::move(handler));
+            ioService_->dispatch(std::forward<CompletionHandlerType>(handler));
         }
         else if(strand_ != nullptr)
         {
-            strand_->dispatch(std::move(handler));
+            strand_->dispatch(std::forward<CompletionHandlerType>(handler));
         }
     }
 

--- a/include/f1x/aasdk/IO/Promise.hpp
+++ b/include/f1x/aasdk/IO/Promise.hpp
@@ -31,7 +31,7 @@ namespace io
 {
 
 template<typename ResolveArgumentType, typename ErrorArgumentType = error::Error>
-class Promise: boost::noncopyable
+class Promise
 {
 public:
     typedef ResolveArgumentType ValueType;
@@ -110,10 +110,12 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
+
+    Promise(const Promise&) = delete;
 };
 
 template<typename ErrorArgumentType>
-class Promise<void, ErrorArgumentType>: boost::noncopyable
+class Promise<void, ErrorArgumentType>
 {
 public:
     typedef ErrorArgumentType ErrorType;
@@ -191,10 +193,12 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
+
+    Promise(const Promise&) = delete;
 };
 
 template<>
-class Promise<void, void>: boost::noncopyable
+class Promise<void, void>
 {
 public:
     typedef std::function<void()> ResolveHandler;
@@ -271,10 +275,12 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
+
+    Promise(const Promise&) = delete;
 };
 
 template<typename ResolveArgumentType>
-class Promise<ResolveArgumentType, void>: boost::noncopyable
+class Promise<ResolveArgumentType, void>
 {
 public:
     typedef ResolveArgumentType ValueType;
@@ -352,6 +358,8 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
+
+    Promise(const Promise&) = delete;
 };
 
 

--- a/include/f1x/aasdk/IO/Promise.hpp
+++ b/include/f1x/aasdk/IO/Promise.hpp
@@ -40,6 +40,8 @@ public:
     typedef std::function<void(ErrorArgumentType)> RejectHandler;
     typedef std::shared_ptr<Promise> Pointer;
 
+    Promise(const Promise&) = delete;
+
     static Pointer defer(boost::asio::io_service& ioService)
     {
         return std::make_shared<Promise>(ioService);
@@ -50,13 +52,13 @@ public:
         return std::make_shared<Promise>(strand);
     }
 
-    Promise(boost::asio::io_service& ioService)
+    explicit Promise(boost::asio::io_service& ioService)
         : ioContextWrapper_(ioService)
     {
 
     }
 
-    Promise(boost::asio::io_service::strand& strand)
+    explicit Promise(boost::asio::io_service::strand& strand)
         : ioContextWrapper_(strand)
     {
 
@@ -110,8 +112,6 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
-
-    Promise(const Promise&) = delete;
 };
 
 template<typename ErrorArgumentType>
@@ -123,6 +123,8 @@ public:
     typedef std::function<void(ErrorArgumentType)> RejectHandler;
     typedef std::shared_ptr<Promise> Pointer;
 
+    Promise(const Promise&) = delete;
+
     static Pointer defer(boost::asio::io_service& ioService)
     {
         return std::make_shared<Promise>(ioService);
@@ -133,13 +135,13 @@ public:
         return std::make_shared<Promise>(strand);
     }
 
-    Promise(boost::asio::io_service& ioService)
+    explicit Promise(boost::asio::io_service& ioService)
         : ioContextWrapper_(ioService)
     {
 
     }
 
-    Promise(boost::asio::io_service::strand& strand)
+    explicit Promise(boost::asio::io_service::strand& strand)
         : ioContextWrapper_(strand)
     {
 
@@ -193,8 +195,6 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
-
-    Promise(const Promise&) = delete;
 };
 
 template<>
@@ -204,6 +204,8 @@ public:
     typedef std::function<void()> ResolveHandler;
     typedef std::function<void()> RejectHandler;
     typedef std::shared_ptr<Promise> Pointer;
+
+    Promise(const Promise&) = delete;
 
     static Pointer defer(boost::asio::io_service& ioService)
     {
@@ -215,13 +217,13 @@ public:
         return std::make_shared<Promise>(strand);
     }
 
-    Promise(boost::asio::io_service& ioService)
+    explicit Promise(boost::asio::io_service& ioService)
         : ioContextWrapper_(ioService)
     {
 
     }
 
-    Promise(boost::asio::io_service::strand& strand)
+    explicit Promise(boost::asio::io_service::strand& strand)
         : ioContextWrapper_(strand)
     {
 
@@ -275,8 +277,6 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
-
-    Promise(const Promise&) = delete;
 };
 
 template<typename ResolveArgumentType>
@@ -288,6 +288,8 @@ public:
     typedef std::function<void(void)> RejectHandler;
     typedef std::shared_ptr<Promise> Pointer;
 
+    Promise(const Promise&) = delete;
+
     static Pointer defer(boost::asio::io_service& ioService)
     {
         return std::make_shared<Promise>(ioService);
@@ -298,13 +300,13 @@ public:
         return std::make_shared<Promise>(strand);
     }
 
-    Promise(boost::asio::io_service& ioService)
+    explicit Promise(boost::asio::io_service& ioService)
         : ioContextWrapper_(ioService)
     {
 
     }
 
-    Promise(boost::asio::io_service::strand& strand)
+    explicit Promise(boost::asio::io_service::strand& strand)
         : ioContextWrapper_(strand)
     {
 
@@ -358,8 +360,6 @@ private:
     RejectHandler rejectHandler_;
     IOContextWrapper ioContextWrapper_;
     std::mutex mutex_;
-
-    Promise(const Promise&) = delete;
 };
 
 

--- a/include/f1x/aasdk/IO/PromiseLink.hpp
+++ b/include/f1x/aasdk/IO/PromiseLink.hpp
@@ -89,7 +89,7 @@ class PromiseLink<void, void>: public std::enable_shared_from_this<PromiseLink<v
 public:
     typedef std::shared_ptr<PromiseLink<void, void>> Pointer;
 
-    PromiseLink(typename Promise<void>::Pointer promise)
+    explicit PromiseLink(typename Promise<void>::Pointer promise)
         : promise_(std::move(promise))
     {
 

--- a/include/f1x/aasdk/Messenger/ChannelId.hpp
+++ b/include/f1x/aasdk/Messenger/ChannelId.hpp
@@ -41,6 +41,8 @@ enum class ChannelId
     NONE = 255
 };
 
+std::string channelIdToString(ChannelId channelId);
+
 }
 }
 }

--- a/include/f1x/aasdk/Messenger/ChannelId.hpp
+++ b/include/f1x/aasdk/Messenger/ChannelId.hpp
@@ -41,8 +41,6 @@ enum class ChannelId
     NONE = 255
 };
 
-std::string channelIdToString(ChannelId channelId);
-
 }
 }
 }

--- a/include/f1x/aasdk/Messenger/Cryptor.hpp
+++ b/include/f1x/aasdk/Messenger/Cryptor.hpp
@@ -32,7 +32,7 @@ namespace messenger
 class Cryptor: public ICryptor
 {
 public:
-    Cryptor(transport::ISSLWrapper::Pointer sslWrapper);
+    explicit Cryptor(transport::ISSLWrapper::Pointer sslWrapper);
 
     void init() override;
     void deinit() override;

--- a/include/f1x/aasdk/Messenger/EncryptionType.hpp
+++ b/include/f1x/aasdk/Messenger/EncryptionType.hpp
@@ -28,7 +28,7 @@ namespace messenger
 enum class EncryptionType
 {
     PLAIN,
-    ENCRYPTED = 1 << 3
+    ENCRYPTED = 1u << 3u
 };
 
 }

--- a/include/f1x/aasdk/Messenger/FrameHeader.hpp
+++ b/include/f1x/aasdk/Messenger/FrameHeader.hpp
@@ -34,7 +34,7 @@ namespace messenger
 class FrameHeader
 {
 public:
-    FrameHeader(const common::DataConstBuffer& buffer);
+    explicit FrameHeader(const common::DataConstBuffer& buffer);
     FrameHeader(ChannelId channelId, FrameType frameType, EncryptionType encryptionType, MessageType messageType);
 
     ChannelId getChannelId() const;

--- a/include/f1x/aasdk/Messenger/FrameSize.hpp
+++ b/include/f1x/aasdk/Messenger/FrameSize.hpp
@@ -32,8 +32,8 @@ class FrameSize
 {
 public:
     FrameSize(size_t frameSize, size_t totalSize);
-    FrameSize(size_t frameSize);
-    FrameSize(const common::DataConstBuffer& buffer);
+    explicit FrameSize(size_t frameSize);
+    explicit FrameSize(const common::DataConstBuffer& buffer);
 
     common::Data getData() const;
     size_t getSize() const;

--- a/include/f1x/aasdk/Messenger/FrameType.hpp
+++ b/include/f1x/aasdk/Messenger/FrameType.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace f1x
 {
@@ -30,8 +30,8 @@ namespace messenger
 enum class FrameType
 {
     MIDDLE = 0,
-    FIRST = 1 << 0,
-    LAST = 1 << 1,
+    FIRST = 1u << 0u,
+    LAST = 1u << 1u,
     BULK = FIRST | LAST
 };
 

--- a/include/f1x/aasdk/Messenger/Message.hpp
+++ b/include/f1x/aasdk/Messenger/Message.hpp
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <boost/noncopyable.hpp>
 #include <memory>
 #include <google/protobuf/message.h>
 #include <f1x/aasdk/Common/Data.hpp>
@@ -34,7 +33,7 @@ namespace aasdk
 namespace messenger
 {
 
-class Message: boost::noncopyable
+class Message
 {
 public:
     typedef std::shared_ptr<Message> Pointer;
@@ -59,6 +58,8 @@ private:
     EncryptionType encryptionType_;
     MessageType type_;
     common::Data payload_;
+
+    Message(const Message&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/Message.hpp
+++ b/include/f1x/aasdk/Messenger/Message.hpp
@@ -39,8 +39,9 @@ public:
     typedef std::shared_ptr<Message> Pointer;
 
     Message(ChannelId channelId, EncryptionType encryptionType, MessageType type);
-    Message(Message&& other);
-    Message& operator=(Message&& other);
+    Message(Message&& other) noexcept ;
+    Message(const Message&) = delete;
+    Message& operator=(Message&& other) noexcept ;
 
     ChannelId getChannelId() const;
     EncryptionType getEncryptionType() const;
@@ -58,8 +59,6 @@ private:
     EncryptionType encryptionType_;
     MessageType type_;
     common::Data payload_;
-
-    Message(const Message&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageId.hpp
+++ b/include/f1x/aasdk/Messenger/MessageId.hpp
@@ -30,8 +30,8 @@ namespace messenger
 class MessageId
 {
 public:
-    MessageId(uint16_t id);
-    MessageId(const common::Data& data);
+    explicit MessageId(uint16_t id);
+    explicit MessageId(const common::Data& data);
 
     common::Data getData() const;
     static constexpr size_t getSizeOf() { return 2; }

--- a/include/f1x/aasdk/Messenger/MessageInStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageInStream.hpp
@@ -31,7 +31,7 @@ namespace aasdk
 namespace messenger
 {
 
-class MessageInStream: public IMessageInStream, public std::enable_shared_from_this<MessageInStream>, boost::noncopyable
+class MessageInStream: public IMessageInStream, public std::enable_shared_from_this<MessageInStream>
 {
 public:
     MessageInStream(boost::asio::io_service& ioService, transport::ITransport::Pointer transport, ICryptor::Pointer cryptor);
@@ -51,6 +51,8 @@ private:
     FrameType recentFrameType_;
     ReceivePromise::Pointer promise_;
     Message::Pointer message_;
+
+    MessageInStream(const MessageInStream&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageInStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageInStream.hpp
@@ -35,6 +35,7 @@ class MessageInStream: public IMessageInStream, public std::enable_shared_from_t
 {
 public:
     MessageInStream(boost::asio::io_service& ioService, transport::ITransport::Pointer transport, ICryptor::Pointer cryptor);
+    MessageInStream(const MessageInStream&) = delete;
 
     void startReceive(ReceivePromise::Pointer promise) override;
 
@@ -51,8 +52,6 @@ private:
     FrameType recentFrameType_;
     ReceivePromise::Pointer promise_;
     Message::Pointer message_;
-
-    MessageInStream(const MessageInStream&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageOutStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageOutStream.hpp
@@ -32,7 +32,7 @@ namespace aasdk
 namespace messenger
 {
 
-class MessageOutStream: public IMessageOutStream, public std::enable_shared_from_this<MessageOutStream>, boost::noncopyable
+class MessageOutStream: public IMessageOutStream, public std::enable_shared_from_this<MessageOutStream>
 {
 public:
     MessageOutStream(boost::asio::io_service& ioService, transport::ITransport::Pointer transport, ICryptor::Pointer cryptor);
@@ -57,7 +57,9 @@ private:
     size_t remainingSize_;
     SendPromise::Pointer promise_;
 
-        static constexpr size_t cMaxFramePayloadSize = 0x4000;
+    static constexpr size_t cMaxFramePayloadSize = 0x4000;
+
+    MessageOutStream(const MessageOutStream&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageOutStream.hpp
+++ b/include/f1x/aasdk/Messenger/MessageOutStream.hpp
@@ -36,13 +36,14 @@ class MessageOutStream: public IMessageOutStream, public std::enable_shared_from
 {
 public:
     MessageOutStream(boost::asio::io_service& ioService, transport::ITransport::Pointer transport, ICryptor::Pointer cryptor);
+    MessageOutStream(const MessageOutStream&) = delete;
 
     void stream(Message::Pointer message, SendPromise::Pointer promise) override;
 
 private:
     using std::enable_shared_from_this<MessageOutStream>::shared_from_this;
 
-    void streamSplittedMessage();
+    void streamSplitMessage();
     common::Data compoundFrame(FrameType frameType, const common::DataConstBuffer& payloadBuffer);
     void streamEncryptedFrame(FrameType frameType, const common::DataConstBuffer& payloadBuffer);
     void streamPlainFrame(FrameType frameType, const common::DataConstBuffer& payloadBuffer);
@@ -58,8 +59,6 @@ private:
     SendPromise::Pointer promise_;
 
     static constexpr size_t cMaxFramePayloadSize = 0x4000;
-
-    MessageOutStream(const MessageOutStream&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/MessageType.hpp
+++ b/include/f1x/aasdk/Messenger/MessageType.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace f1x
 {
@@ -32,7 +32,7 @@ namespace messenger
 enum class MessageType
 {
     SPECIFIC = 0,
-    CONTROL = 1 << 2
+    CONTROL = 1u << 2u
 };
 
 }

--- a/include/f1x/aasdk/Messenger/Messenger.hpp
+++ b/include/f1x/aasdk/Messenger/Messenger.hpp
@@ -33,7 +33,7 @@ namespace aasdk
 namespace messenger
 {
 
-class Messenger: public IMessenger, public std::enable_shared_from_this<Messenger>, boost::noncopyable
+class Messenger: public IMessenger, public std::enable_shared_from_this<Messenger>
 {
 public:
     Messenger(boost::asio::io_service& ioService, IMessageInStream::Pointer messageInStream, IMessageOutStream::Pointer messageOutStream);
@@ -58,6 +58,8 @@ private:
     ChannelReceivePromiseQueue channelReceivePromiseQueue_;
     ChannelReceiveMessageQueue channelReceiveMessageQueue_;
     ChannelSendQueue channelSendPromiseQueue_;
+
+    Messenger(const Messenger&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/Messenger.hpp
+++ b/include/f1x/aasdk/Messenger/Messenger.hpp
@@ -37,6 +37,8 @@ class Messenger: public IMessenger, public std::enable_shared_from_this<Messenge
 {
 public:
     Messenger(boost::asio::io_service& ioService, IMessageInStream::Pointer messageInStream, IMessageOutStream::Pointer messageOutStream);
+    Messenger(const Messenger&) = delete;
+
     void enqueueReceive(ChannelId channelId, ReceivePromise::Pointer promise) override;
     void enqueueSend(Message::Pointer message, SendPromise::Pointer promise) override;
     void stop() override;
@@ -58,8 +60,6 @@ private:
     ChannelReceivePromiseQueue channelReceivePromiseQueue_;
     ChannelReceiveMessageQueue channelReceiveMessageQueue_;
     ChannelSendQueue channelSendPromiseQueue_;
-
-    Messenger(const Messenger&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/Messenger/Timestamp.hpp
+++ b/include/f1x/aasdk/Messenger/Timestamp.hpp
@@ -32,8 +32,8 @@ class Timestamp
 public:
     typedef uint64_t ValueType;
 
-    Timestamp(ValueType stamp);
-    Timestamp(const common::DataConstBuffer& buffer);
+    explicit Timestamp(ValueType stamp);
+    explicit Timestamp(const common::DataConstBuffer& buffer);
 
     common::Data getData() const;
     ValueType getValue() const;

--- a/include/f1x/aasdk/Transport/Transport.hpp
+++ b/include/f1x/aasdk/Transport/Transport.hpp
@@ -31,13 +31,16 @@ namespace aasdk
 namespace transport
 {
 
-class Transport: public ITransport, public std::enable_shared_from_this<Transport>, boost::noncopyable
+class Transport: public ITransport, public std::enable_shared_from_this<Transport>
 {
 public:
     Transport(boost::asio::io_service& ioService);
 
     void receive(size_t size, ReceivePromise::Pointer promise) override;
     void send(common::Data data, SendPromise::Pointer promise) override;
+
+private:
+    Transport(const Transport&) = delete;
 
 protected:
     typedef std::list<std::pair<size_t, ReceivePromise::Pointer>> ReceiveQueue;

--- a/include/f1x/aasdk/Transport/Transport.hpp
+++ b/include/f1x/aasdk/Transport/Transport.hpp
@@ -34,13 +34,11 @@ namespace transport
 class Transport: public ITransport, public std::enable_shared_from_this<Transport>
 {
 public:
-    Transport(boost::asio::io_service& ioService);
+    explicit Transport(boost::asio::io_service& ioService);
+    Transport(const Transport&) = delete;
 
     void receive(size_t size, ReceivePromise::Pointer promise) override;
     void send(common::Data data, SendPromise::Pointer promise) override;
-
-private:
-    Transport(const Transport&) = delete;
 
 protected:
     typedef std::list<std::pair<size_t, ReceivePromise::Pointer>> ReceiveQueue;

--- a/include/f1x/aasdk/USB/AOAPDevice.hpp
+++ b/include/f1x/aasdk/USB/AOAPDevice.hpp
@@ -31,7 +31,7 @@ namespace aasdk
 namespace usb
 {
 
-class AOAPDevice: public IAOAPDevice, boost::noncopyable
+class AOAPDevice: public IAOAPDevice
 {
 public:
     AOAPDevice(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, DeviceHandle handle, const libusb_interface_descriptor* interfaceDescriptor);
@@ -56,6 +56,8 @@ private:
     static constexpr uint16_t cGoogleVendorId = 0x18D1;
     static constexpr uint16_t cAOAPId = 0x2D00;
     static constexpr uint16_t cAOAPWithAdbId = 0x2D01;
+
+    AOAPDevice(const AOAPDevice&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/AOAPDevice.hpp
+++ b/include/f1x/aasdk/USB/AOAPDevice.hpp
@@ -36,6 +36,7 @@ class AOAPDevice: public IAOAPDevice
 public:
     AOAPDevice(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, DeviceHandle handle, const libusb_interface_descriptor* interfaceDescriptor);
     ~AOAPDevice() override;
+    AOAPDevice(const AOAPDevice&) = delete;
 
     IUSBEndpoint& getInEndpoint() override;
     IUSBEndpoint& getOutEndpoint() override;
@@ -56,8 +57,6 @@ private:
     static constexpr uint16_t cGoogleVendorId = 0x18D1;
     static constexpr uint16_t cAOAPId = 0x2D00;
     static constexpr uint16_t cAOAPWithAdbId = 0x2D01;
-
-    AOAPDevice(const AOAPDevice&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/AccessoryModeQuery.hpp
+++ b/include/f1x/aasdk/USB/AccessoryModeQuery.hpp
@@ -32,11 +32,14 @@ namespace aasdk
 namespace usb
 {
 
-class AccessoryModeQuery: public IAccessoryModeQuery, boost::noncopyable
+class AccessoryModeQuery: public IAccessoryModeQuery
 {
 public:
     AccessoryModeQuery(boost::asio::io_service& ioService, IUSBEndpoint::Pointer usbEndpoint);
     void cancel() override;
+
+private:
+    AccessoryModeQuery(const AccessoryModeQuery&) = delete;
 
 protected:
     boost::asio::io_service::strand strand_;

--- a/include/f1x/aasdk/USB/AccessoryModeQuery.hpp
+++ b/include/f1x/aasdk/USB/AccessoryModeQuery.hpp
@@ -36,10 +36,8 @@ class AccessoryModeQuery: public IAccessoryModeQuery
 {
 public:
     AccessoryModeQuery(boost::asio::io_service& ioService, IUSBEndpoint::Pointer usbEndpoint);
-    void cancel() override;
-
-private:
     AccessoryModeQuery(const AccessoryModeQuery&) = delete;
+    void cancel() override;
 
 protected:
     boost::asio::io_service::strand strand_;

--- a/include/f1x/aasdk/USB/AccessoryModeQueryChain.hpp
+++ b/include/f1x/aasdk/USB/AccessoryModeQueryChain.hpp
@@ -31,7 +31,7 @@ namespace usb
     
 class IAccessoryModeQueryFactory;
 
-class AccessoryModeQueryChain: public IAccessoryModeQueryChain, public std::enable_shared_from_this<AccessoryModeQueryChain>, boost::noncopyable
+class AccessoryModeQueryChain: public IAccessoryModeQueryChain, public std::enable_shared_from_this<AccessoryModeQueryChain>
 {
 public:
     AccessoryModeQueryChain(IUSBWrapper& usbWrapper,
@@ -61,6 +61,8 @@ private:
     DeviceHandle handle_;    
     Promise::Pointer promise_;
     IAccessoryModeQuery::Pointer activeQuery_;
+
+    AccessoryModeQueryChain(const AccessoryModeQueryChain&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/AccessoryModeQueryChain.hpp
+++ b/include/f1x/aasdk/USB/AccessoryModeQueryChain.hpp
@@ -37,6 +37,7 @@ public:
     AccessoryModeQueryChain(IUSBWrapper& usbWrapper,
                             boost::asio::io_service& ioService,
                             IAccessoryModeQueryFactory& queryFactory);
+    AccessoryModeQueryChain(const AccessoryModeQueryChain&) = delete;
 
     void start(DeviceHandle handle, Promise::Pointer promise) override;
     void cancel() override;
@@ -61,8 +62,6 @@ private:
     DeviceHandle handle_;    
     Promise::Pointer promise_;
     IAccessoryModeQuery::Pointer activeQuery_;
-
-    AccessoryModeQueryChain(const AccessoryModeQueryChain&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/IUSBWrapper.hpp
+++ b/include/f1x/aasdk/USB/IUSBWrapper.hpp
@@ -34,7 +34,7 @@ typedef std::shared_ptr<libusb_device_handle> DeviceHandle;
 typedef std::list<libusb_device*> DeviceList;
 typedef std::shared_ptr<DeviceList> DeviceListHandle;
 typedef std::shared_ptr<libusb_config_descriptor> ConfigDescriptorHandle;
-typedef std::shared_ptr<libusb_hotplug_callback_handle> HotplugCallbackHandle;
+typedef std::shared_ptr<libusb_hotplug_callback_handle> HotPlugCallbackHandle;
 
 class IUSBWrapper
 {
@@ -73,7 +73,7 @@ public:
         uint16_t wLength) = 0;
     virtual int getDeviceDescriptor(libusb_device *dev, libusb_device_descriptor &desc) = 0;
     virtual void handleEvents() = 0;
-    virtual HotplugCallbackHandle hotplugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
+    virtual HotPlugCallbackHandle hotPlugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
                                                           libusb_hotplug_callback_fn cb_fn, void *user_data) = 0;
     virtual libusb_transfer* allocTransfer(int iso_packets) = 0;
 };

--- a/include/f1x/aasdk/USB/USBEndpoint.hpp
+++ b/include/f1x/aasdk/USB/USBEndpoint.hpp
@@ -32,8 +32,7 @@ namespace usb
 {
 
 class USBEndpoint: public IUSBEndpoint,
-        public std::enable_shared_from_this<USBEndpoint>,
-        boost::noncopyable
+        public std::enable_shared_from_this<USBEndpoint>
 {
 public:
     USBEndpoint(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, DeviceHandle handle, uint8_t endpointAddress = 0x00);
@@ -58,6 +57,8 @@ private:
     uint8_t endpointAddress_;
     Transfers transfers_;
     std::shared_ptr<USBEndpoint> self_;
+
+    USBEndpoint(const USBEndpoint&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/USBEndpoint.hpp
+++ b/include/f1x/aasdk/USB/USBEndpoint.hpp
@@ -36,6 +36,7 @@ class USBEndpoint: public IUSBEndpoint,
 {
 public:
     USBEndpoint(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, DeviceHandle handle, uint8_t endpointAddress = 0x00);
+    USBEndpoint(const USBEndpoint&) = delete;
 
     void controlTransfer(common::DataBuffer buffer, uint32_t timeout, Promise::Pointer promise) override;
     void bulkTransfer(common::DataBuffer buffer, uint32_t timeout, Promise::Pointer promise) override;
@@ -57,8 +58,6 @@ private:
     uint8_t endpointAddress_;
     Transfers transfers_;
     std::shared_ptr<USBEndpoint> self_;
-
-    USBEndpoint(const USBEndpoint&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/USBHub.hpp
+++ b/include/f1x/aasdk/USB/USBHub.hpp
@@ -32,7 +32,7 @@ namespace usb
 
 class IUSBWrapper;
 
-class USBHub: public IUSBHub, public std::enable_shared_from_this<USBHub>, boost::noncopyable
+class USBHub: public IUSBHub, public std::enable_shared_from_this<USBHub>
 {
 public:
     USBHub(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, IAccessoryModeQueryChainFactory& queryChainFactory);
@@ -58,6 +58,8 @@ private:
     static constexpr uint16_t cGoogleVendorId = 0x18D1;
     static constexpr uint16_t cAOAPId = 0x2D00;
     static constexpr uint16_t cAOAPWithAdbId = 0x2D01;
+
+    USBHub(const USBHub&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/USBHub.hpp
+++ b/include/f1x/aasdk/USB/USBHub.hpp
@@ -36,6 +36,7 @@ class USBHub: public IUSBHub, public std::enable_shared_from_this<USBHub>
 {
 public:
     USBHub(IUSBWrapper& usbWrapper, boost::asio::io_service& ioService, IAccessoryModeQueryChainFactory& queryChainFactory);
+    USBHub(const USBHub&) = delete;
 
     void start(Promise::Pointer promise) override;
     void cancel() override;
@@ -45,21 +46,19 @@ private:
     using std::enable_shared_from_this<USBHub>::shared_from_this;
     void handleDevice(libusb_device* device);
     bool isAOAPDevice(const libusb_device_descriptor& deviceDescriptor) const;
-    static int hotplugEventsHandler(libusb_context* usbContext, libusb_device* device, libusb_hotplug_event event, void* uerData);
+    static int hotPlugEventsHandler(libusb_context* usbContext, libusb_device* device, libusb_hotplug_event event, void* uerData);
 
     IUSBWrapper& usbWrapper_;
     boost::asio::io_service::strand strand_;
     IAccessoryModeQueryChainFactory& queryChainFactory_;
-    Promise::Pointer hotplugPromise_;
+    Promise::Pointer hotPlugPromise_;
     Pointer self_;
-    HotplugCallbackHandle hotplugHandle_;
+    HotPlugCallbackHandle hotPlugHandle_;
     QueryChainQueue queryChainQueue_;
 
     static constexpr uint16_t cGoogleVendorId = 0x18D1;
     static constexpr uint16_t cAOAPId = 0x2D00;
     static constexpr uint16_t cAOAPWithAdbId = 0x2D01;
-
-    USBHub(const USBHub&) = delete;
 };
 
 }

--- a/include/f1x/aasdk/USB/USBWrapper.hpp
+++ b/include/f1x/aasdk/USB/USBWrapper.hpp
@@ -30,7 +30,7 @@ namespace usb
 class USBWrapper: public IUSBWrapper
 {
 public:
-    USBWrapper(libusb_context* usbContext);
+    explicit USBWrapper(libusb_context* usbContext);
 
     int releaseInterface(const DeviceHandle& dev_handle, int interface_number) override;
     libusb_device* getDevice(const DeviceHandle& dev_handle) override;
@@ -64,7 +64,7 @@ public:
         uint16_t wLength) override;
     int getDeviceDescriptor(libusb_device *dev, libusb_device_descriptor &desc) override;
     void handleEvents() override;
-    HotplugCallbackHandle hotplugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
+    HotPlugCallbackHandle hotPlugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
                                                   libusb_hotplug_callback_fn cb_fn, void *user_data) override;
     libusb_transfer* allocTransfer(int iso_packets) override;
 

--- a/include/f1x/aasdk/Version.hpp
+++ b/include/f1x/aasdk/Version.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 static const uint16_t AASDK_MAJOR = 1;
 static const uint16_t AASDK_MINOR = 1;

--- a/include_ut/f1x/aasdk/USB/UT/USBWrapper.mock.hpp
+++ b/include_ut/f1x/aasdk/USB/UT/USBWrapper.mock.hpp
@@ -67,7 +67,8 @@ public:
         uint16_t wLength));
     MOCK_METHOD2(getDeviceDescriptor, int(libusb_device *dev, libusb_device_descriptor &desc));
     MOCK_METHOD0(handleEvents, void());
-    MOCK_METHOD7(hotplugRegisterCallback, HotplugCallbackHandle(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
+    MOCK_METHOD7(hotPlugRegisterCallback,
+                 HotPlugCallbackHandle(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
                                                                 libusb_hotplug_callback_fn cb_fn, void *user_data));
     MOCK_METHOD1(allocTransfer, libusb_transfer*(int iso_packets));
 };

--- a/src/Channel/ServiceChannel.cpp
+++ b/src/Channel/ServiceChannel.cpp
@@ -38,7 +38,7 @@ ServiceChannel::ServiceChannel(boost::asio::io_service::strand& strand,
 
 void ServiceChannel::send(messenger::Message::Pointer message, SendPromise::Pointer promise)
 {
-    auto sendPromise = messenger::SendPromise::defer(strand_.get_io_service());
+    auto sendPromise = messenger::SendPromise::defer(strand_.context());
     io::PromiseLink<>::forward(*sendPromise, std::move(promise));
     messenger_->enqueueSend(std::move(message), std::move(sendPromise));
 }

--- a/src/Messenger/Message.cpp
+++ b/src/Messenger/Message.cpp
@@ -32,7 +32,7 @@ Message::Message(ChannelId channelId, EncryptionType encryptionType, MessageType
 {
 }
 
-Message::Message(Message&& other)
+Message::Message(Message&& other) noexcept
     : channelId_(other.channelId_)
     , encryptionType_(other.encryptionType_)
     , type_(other.type_)
@@ -41,7 +41,7 @@ Message::Message(Message&& other)
 
 }
 
-Message& Message::operator=(Message&& other)
+Message& Message::operator=(Message&& other) noexcept
 {
     channelId_ = std::move(other.channelId_);
     encryptionType_ = std::move(other.encryptionType_);

--- a/src/Messenger/MessageId.cpp
+++ b/src/Messenger/MessageId.cpp
@@ -44,7 +44,7 @@ uint16_t MessageId::getId() const
 
 common::Data MessageId::getData() const
 {
-    const MessageId messageIdBig = boost::endian::native_to_big(id_);
+    const unsigned short messageIdBig = boost::endian::native_to_big(id_);
     const common::DataConstBuffer messageIdBigBuffer(&messageIdBig, sizeof(messageIdBig));
     return common::createData(messageIdBigBuffer);
 }

--- a/src/Messenger/MessageInStream.ut.cpp
+++ b/src/Messenger/MessageInStream.ut.cpp
@@ -134,7 +134,7 @@ BOOST_FIXTURE_TEST_CASE(MessageInStream_ReceiveEncryptedMessage, MessageInStream
     EXPECT_CALL(transportMock_, receive(framePayload.size(), _)).WillOnce(SaveArg<1>(&framePayloadTransportPromise));
 
     common::Data decryptedPayload(500, 0x5F);
-    EXPECT_CALL(cryptorMock_, decrypt(_, _)).WillOnce(DoAll(SetArgReferee<0>(decryptedPayload), Return(decryptedPayload.size())));
+    EXPECT_CALL(cryptorMock_, decrypt(_, _)).WillOnce(testing::DoAll(SetArgReferee<0>(decryptedPayload), Return(decryptedPayload.size())));
     frameSizeTransportPromise->resolve(frameSize.getData());
 
     ioService_.run();

--- a/src/Messenger/MessageOutStream.cpp
+++ b/src/Messenger/MessageOutStream.cpp
@@ -53,7 +53,7 @@ void MessageOutStream::stream(Message::Pointer message, SendPromise::Pointer pro
         {
             offset_ = 0;
             remainingSize_ = message_->getPayload().size();
-            this->streamSplittedMessage();
+            this->streamSplitMessage();
         }
         else
         {
@@ -76,7 +76,7 @@ void MessageOutStream::stream(Message::Pointer message, SendPromise::Pointer pro
     });
 }
 
-void MessageOutStream::streamSplittedMessage()
+void MessageOutStream::streamSplitMessage()
 {
     try
     {
@@ -99,7 +99,7 @@ void MessageOutStream::streamSplittedMessage()
             transportPromise->then([this, self = this->shared_from_this(), size]() mutable {
                     offset_ += size;
                     remainingSize_ -= size;
-                    this->streamSplittedMessage();
+                    this->streamSplitMessage();
                 },
                 [this, self = this->shared_from_this()](const error::Error& e) mutable {
                     this->reset();

--- a/src/Messenger/MessageOutStream.ut.cpp
+++ b/src/Messenger/MessageOutStream.ut.cpp
@@ -109,7 +109,7 @@ BOOST_FIXTURE_TEST_CASE(MessageOutStream_SendEncryptedMessage, MessageOutStreamU
     common::Data encryptedData(expectedData.begin(), expectedData.begin() + FrameHeader::getSizeOf() + FrameSize::getSizeOf(FrameSizeType::SHORT));
     encryptedData.insert(encryptedData.end(), encryptedPayload.begin(), encryptedPayload.end());
     transport::ITransport::SendPromise::Pointer transportSendPromise;
-    EXPECT_CALL(cryptorMock_, encrypt(_, _)).WillOnce(DoAll(SetArgReferee<0>(encryptedData), Return(encryptedPayload.size())));
+    EXPECT_CALL(cryptorMock_, encrypt(_, _)).WillOnce(testing::DoAll(SetArgReferee<0>(encryptedData), Return(encryptedPayload.size())));
     EXPECT_CALL(transportMock_, send(expectedData, _)).WillOnce(SaveArg<1>(&transportSendPromise));
 
     Message::Pointer message(std::make_shared<Message>(ChannelId::VIDEO, EncryptionType::ENCRYPTED, MessageType::CONTROL));

--- a/src/TCP/TCPEndpoint.ut.cpp
+++ b/src/TCP/TCPEndpoint.ut.cpp
@@ -57,7 +57,7 @@ BOOST_FIXTURE_TEST_CASE(TCPEndpoint_Receive, TCPEndpointUnitTest)
 
     common::DataBuffer buffer;
     ITCPWrapper::Handler handler;
-    EXPECT_CALL(tcpWrapperMock_, asyncRead(_, _, _)).WillOnce(DoAll(SaveArg<1>(&buffer), SaveArg<2>(&handler)));
+    EXPECT_CALL(tcpWrapperMock_, asyncRead(_, _, _)).WillOnce(testing::DoAll(SaveArg<1>(&buffer), SaveArg<2>(&handler)));
 
     common::Data actualData(100, 0);
     tcpEndpoint->receive(common::DataBuffer(actualData), std::move(promise_));
@@ -80,7 +80,7 @@ BOOST_FIXTURE_TEST_CASE(TCPEndpoint_ReceiveError, TCPEndpointUnitTest)
 
     common::DataBuffer buffer;
     ITCPWrapper::Handler handler;
-    EXPECT_CALL(tcpWrapperMock_, asyncRead(_, _, _)).WillOnce(DoAll(SaveArg<1>(&buffer), SaveArg<2>(&handler)));
+    EXPECT_CALL(tcpWrapperMock_, asyncRead(_, _, _)).WillOnce(testing::DoAll(SaveArg<1>(&buffer), SaveArg<2>(&handler)));
 
     common::Data actualData(100, 0);
     tcpEndpoint->receive(common::DataBuffer(actualData), std::move(promise_));

--- a/src/Transport/TCPTransport.ut.cpp
+++ b/src/Transport/TCPTransport.ut.cpp
@@ -66,7 +66,7 @@ BOOST_FIXTURE_TEST_CASE(TCPTransport_ReceiveAtOnce, TCPTransportUnitTest)
 
     tcp::ITCPEndpoint::Promise::Pointer tcpEndpointPromise;
     common::DataBuffer dataBuffer;
-    EXPECT_CALL(tcpEndpointMock_, receive(_, _)).WillOnce(DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
+    EXPECT_CALL(tcpEndpointMock_, receive(_, _)).WillOnce(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
 
     auto transport(std::make_shared<TCPTransport>(ioService_, tcpEndpoint_));
     transport->receive(receiveSize, std::move(receivePromise_));
@@ -95,7 +95,7 @@ BOOST_FIXTURE_TEST_CASE(TCPTransport_ReceiveInPieces, TCPTransportUnitTest)
     tcp::ITCPEndpoint::Promise::Pointer tcpEndpointPromise;
     common::DataBuffer dataBuffer;
     EXPECT_CALL(tcpEndpointMock_, receive(_, _)).Times(AtLeast(stepsCount))
-            .WillRepeatedly(DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
+            .WillRepeatedly(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
 
     common::Data expectedData(receiveSize, 0x5E);
     EXPECT_CALL(receivePromiseHandlerMock_, onResolve(expectedData)).Times(1);
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(TCPTransport_OnlyOneReceiveAtATime, TCPTransportUnitTest
 
     tcp::ITCPEndpoint::Promise::Pointer tcpEndpointPromise;
     common::DataBuffer dataBuffer;
-    EXPECT_CALL(tcpEndpointMock_, receive(_, _)).WillOnce(DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
+    EXPECT_CALL(tcpEndpointMock_, receive(_, _)).WillOnce(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<1>(&tcpEndpointPromise)));
 
     auto transport(std::make_shared<TCPTransport>(ioService_, tcpEndpoint_));
     transport->receive(stepSize, std::move(receivePromise_));
@@ -181,7 +181,7 @@ BOOST_FIXTURE_TEST_CASE(TCPTransport_Send, TCPTransportUnitTest)
 {
     tcp::ITCPEndpoint::Promise::Pointer tcpEndpointPromise;
     common::DataConstBuffer buffer;
-    EXPECT_CALL(tcpEndpointMock_, send(_, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<1>(&tcpEndpointPromise)));
+    EXPECT_CALL(tcpEndpointMock_, send(_, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<1>(&tcpEndpointPromise)));
 
     auto transport(std::make_shared<TCPTransport>(ioService_, tcpEndpoint_));
     const common::Data expectedData(1000, 0x5E);
@@ -202,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE(TCPTransport_OnlyOneSendAtATime, TCPTransportUnitTest)
 {
     tcp::ITCPEndpoint::Promise::Pointer tcpEndpointPromise;
     common::DataConstBuffer buffer;
-    EXPECT_CALL(tcpEndpointMock_, send(_, _)).Times(2).WillRepeatedly(DoAll(SaveArg<0>(&buffer), SaveArg<1>(&tcpEndpointPromise)));
+    EXPECT_CALL(tcpEndpointMock_, send(_, _)).Times(2).WillRepeatedly(testing::DoAll(SaveArg<0>(&buffer), SaveArg<1>(&tcpEndpointPromise)));
 
     auto transport(std::make_shared<TCPTransport>(ioService_, tcpEndpoint_));
     const common::Data expectedData1(1000, 0x5E);

--- a/src/Transport/USBTransport.ut.cpp
+++ b/src/Transport/USBTransport.ut.cpp
@@ -72,7 +72,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_ReceiveAtOnce, USBTransportUnitTest)
 
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer dataBuffer;
-    EXPECT_CALL(inEndpointMock_, bulkTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(inEndpointMock_, bulkTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
 
     USBTransport::Pointer transport(std::make_shared<USBTransport>(ioService_, aoapDevice_));
     transport->receive(receiveSize, std::move(receivePromise_));
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_ReceiveInPieces, USBTransportUnitTest)
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer dataBuffer;
     EXPECT_CALL(inEndpointMock_, bulkTransfer(_, _, _)).Times(AtLeast(stepsCount))
-            .WillRepeatedly(DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
+            .WillRepeatedly(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
 
     common::Data expectedData(receiveSize, 0x5E);
     EXPECT_CALL(receivePromiseHandlerMock_, onResolve(expectedData)).Times(1);
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_OnlyOneReceiveAtATime, USBTransportUnitTest
 
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer dataBuffer;
-    EXPECT_CALL(inEndpointMock_, bulkTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(inEndpointMock_, bulkTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&dataBuffer), SaveArg<2>(&usbEndpointPromise)));
 
     USBTransport::Pointer transport(std::make_shared<USBTransport>(ioService_, aoapDevice_));
     transport->receive(stepSize, std::move(receivePromise_));
@@ -187,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_Send, USBTransportUnitTest)
 {
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer buffer;
-    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     USBTransport::Pointer transport(std::make_shared<USBTransport>(ioService_, aoapDevice_));
     const common::Data expectedData(1000, 0x5E);
@@ -208,7 +208,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_SendInPieces, USBTransportUnitTest)
 {
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer buffer;
-    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).Times(2).WillRepeatedly(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).Times(2).WillRepeatedly(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     const common::Data expectedDataPiece1(1000, 0x5E);
     const common::Data expectedDataPiece2(2000, 0x5F);
@@ -239,7 +239,7 @@ BOOST_FIXTURE_TEST_CASE(USBTransport_OnlyOneSendAtATime, USBTransportUnitTest)
 {
     usb::IUSBEndpoint::Promise::Pointer usbEndpointPromise;
     common::DataBuffer buffer;
-    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).Times(2).WillRepeatedly(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(outEndpointMock_, bulkTransfer(_, _, _)).Times(2).WillRepeatedly(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     USBTransport::Pointer transport(std::make_shared<USBTransport>(ioService_, aoapDevice_));
     const common::Data expectedData1(1000, 0x5E);

--- a/src/USB/AccessoryModeProtocolVersionQuery.ut.cpp
+++ b/src/USB/AccessoryModeProtocolVersionQuery.ut.cpp
@@ -51,7 +51,7 @@ protected:
     {
         common::DataBuffer buffer;
         IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-        EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+        EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
         EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_IN | USB_TYPE_VENDOR, ACC_REQ_GET_PROTOCOL, 0, 0, sizeof(protocolVersion)));
 
         AccessoryModeProtocolVersionQuery::Pointer query(std::make_shared<AccessoryModeProtocolVersionQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));
@@ -94,7 +94,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeProtocolVersionQuery_InvalidProtocolVersion
 
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_IN | USB_TYPE_VENDOR, ACC_REQ_GET_PROTOCOL, 0, 0, sizeof(protocolVersion)));
 
     AccessoryModeProtocolVersionQuery::Pointer query(std::make_shared<AccessoryModeProtocolVersionQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));
@@ -116,7 +116,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeProtocolVersionQuery_TransferError, Accesso
 
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_IN | USB_TYPE_VENDOR, ACC_REQ_GET_PROTOCOL, 0, 0, sizeof(protocolVersion)));
 
     AccessoryModeProtocolVersionQuery::Pointer query(std::make_shared<AccessoryModeProtocolVersionQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeProtocolVersionQuery_RejectWhenInProgress, 
 
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_IN | USB_TYPE_VENDOR, ACC_REQ_GET_PROTOCOL, 0, 0, sizeof(protocolVersion)));
 
     AccessoryModeProtocolVersionQuery::Pointer query(std::make_shared<AccessoryModeProtocolVersionQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));

--- a/src/USB/AccessoryModeQueryChain.cpp
+++ b/src/USB/AccessoryModeQueryChain.cpp
@@ -58,7 +58,7 @@ void AccessoryModeQueryChain::start(DeviceHandle handle, Promise::Pointer promis
                 });
 
             this->startQuery(AccessoryModeQueryType::PROTOCOL_VERSION,
-                             std::make_shared<USBEndpoint>(usbWrapper_, strand_.get_io_service(), std::move(handle)),
+                             std::make_shared<USBEndpoint>(usbWrapper_, strand_.context(), std::move(handle)),
                              std::move(queryPromise));
         }
     });

--- a/src/USB/AccessoryModeQueryChain.ut.cpp
+++ b/src/USB/AccessoryModeQueryChain.ut.cpp
@@ -67,7 +67,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_QueryAOAPDevice, AccessoryModeQu
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
     ioService_.run();
     ioService_.reset();
@@ -121,7 +121,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_ProtocolVersionQueryFailed, Acce
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -142,7 +142,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_ManufacturerQueryFailed, Accesso
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -168,7 +168,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_ModelQueryFailed, AccessoryModeQ
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_DescriptionQueryFailed, Accessor
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -235,7 +235,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_VersionQueryFailed, AccessoryMod
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -276,7 +276,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_URIQueryFailed, AccessoryModeQue
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -322,7 +322,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_SerialQueryFailed, AccessoryMode
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -373,7 +373,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_StartQueryFailed, AccessoryModeQ
 
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();
@@ -428,7 +428,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeQueryChain_Cancel, AccessoryModeQueryChainU
     IUSBEndpoint::Pointer usbEndpoint;
     IAccessoryModeQuery::Promise::Pointer queryPromise;
     EXPECT_CALL(*queryMock_, start(_)).WillRepeatedly(SaveArg<0>(&queryPromise));
-    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
+    EXPECT_CALL(queryFactoryMock_, createQuery(AccessoryModeQueryType::PROTOCOL_VERSION, _)).WillOnce(testing::DoAll(SaveArg<1>(&usbEndpoint), Return(queryMock_)));
     queryChain->start(deviceHandle_, std::move(promise_));
 
     ioService_.run();

--- a/src/USB/AccessoryModeSendStringQuery.ut.cpp
+++ b/src/USB/AccessoryModeSendStringQuery.ut.cpp
@@ -62,7 +62,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeSendStringQuery_SendString, AccessoryModeSe
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     const std::string expectedQueryString = "aasdkTest";
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_SEND_STRING, 0, static_cast<uint16_t>(AccessoryModeSendStringType::MANUFACTURER), expectedQueryString.size() + 1));
@@ -88,7 +88,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeSendStringQuery_TransferError, AccessoryMod
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     const std::string expectedQueryString = "aasdkTest";
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_SEND_STRING, 0, static_cast<uint16_t>(AccessoryModeSendStringType::MANUFACTURER), expectedQueryString.size() + 1));
@@ -111,7 +111,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeSendStringQuery_RejectWhenInProgress, Acces
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
 
     const std::string expectedQueryString = "aasdkTest";
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_SEND_STRING, 0, static_cast<uint16_t>(AccessoryModeSendStringType::MANUFACTURER), expectedQueryString.size() + 1));

--- a/src/USB/AccessoryModeStartQuery.ut.cpp
+++ b/src/USB/AccessoryModeStartQuery.ut.cpp
@@ -62,7 +62,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeStartQuery_Start, AccessoryModeStartQueryUn
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_START, 0, 0, 0));
 
     AccessoryModeStartQuery::Pointer query(std::make_shared<AccessoryModeStartQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));
@@ -81,7 +81,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeStartQuery_TransferError, AccessoryModeStar
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_START, 0, 0, 0));
 
     AccessoryModeStartQuery::Pointer query(std::make_shared<AccessoryModeStartQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(AccessoryModeStartQuery_RejectWhenInProgress, AccessoryM
 {
     common::DataBuffer buffer;
     IUSBEndpoint::Promise::Pointer usbEndpointPromise;
-    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
+    EXPECT_CALL(*usbEndpointMock_, controlTransfer(_, _, _)).WillOnce(testing::DoAll(SaveArg<0>(&buffer), SaveArg<2>(&usbEndpointPromise)));
     EXPECT_CALL(usbWrapperMock_, fillControlSetup(NotNull(), LIBUSB_ENDPOINT_OUT | USB_TYPE_VENDOR, ACC_REQ_START, 0, 0, 0));
 
     AccessoryModeStartQuery::Pointer query(std::make_shared<AccessoryModeStartQuery>(ioService_, usbWrapperMock_, usbEndpointMock_));

--- a/src/USB/ConnectedAccessoriesEnumerator.ut.cpp
+++ b/src/USB/ConnectedAccessoriesEnumerator.ut.cpp
@@ -71,10 +71,10 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_FirstDeviceIsAOAPCapables
     EXPECT_CALL(queryChainFactoryMock_, create()).WillOnce(Return(queryChain_));
     auto connectedAccessoriesEnumerator(std::make_shared<ConnectedAccessoriesEnumerator>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
     connectedAccessoriesEnumerator->enumerate(std::move(promise_));
 
-    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
 
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise;
     EXPECT_CALL(queryChainMock_, start(deviceHandle_, _)).WillOnce(SaveArg<1>(&queryChainPromise));
@@ -94,10 +94,10 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_SecondDeviceIsAOAPCapable
     auto connectedAccessoriesEnumerator(std::make_shared<ConnectedAccessoriesEnumerator>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
 
     EXPECT_CALL(queryChainFactoryMock_, create()).Times(deviceList_.size()).WillRepeatedly(Return(queryChain_));
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
     connectedAccessoriesEnumerator->enumerate(std::move(promise_));
 
-    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise;
     EXPECT_CALL(queryChainMock_, start(deviceHandle_, _)).WillRepeatedly(SaveArg<1>(&queryChainPromise));
     ioService_.run();
@@ -109,7 +109,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_SecondDeviceIsAOAPCapable
     // open second device
     USBWrapperMock::DummyDeviceHandle dummyDeviceHandle2;
     DeviceHandle deviceHandle2(reinterpret_cast<libusb_device_handle*>(&dummyDeviceHandle2), [](auto*) {});
-    EXPECT_CALL(usbWrapperMock_, open(*(++deviceList_.begin()), _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle2), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(*(++deviceList_.begin()), _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle2), Return(0)));
 
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise2;
     EXPECT_CALL(queryChainMock_, start(deviceHandle2, _)).WillRepeatedly(SaveArg<1>(&queryChainPromise2));
@@ -131,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_NoAOAPCapableDevice, Conn
         deviceList_.push_back(reinterpret_cast<libusb_device*>(i));
     }
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
     EXPECT_CALL(queryChainFactoryMock_, create()).Times(deviceList_.size()).WillRepeatedly(Return(queryChain_));
 
     auto connectedAccessoriesEnumerator(std::make_shared<ConnectedAccessoriesEnumerator>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
@@ -144,7 +144,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_NoAOAPCapableDevice, Conn
     {
         USBWrapperMock::DummyDeviceHandle dummyDeviceHandle;
         DeviceHandle deviceHandle(reinterpret_cast<libusb_device_handle*>(&dummyDeviceHandle), [](auto*) {});
-        EXPECT_CALL(usbWrapperMock_, open(device, _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle), Return(0)));
+        EXPECT_CALL(usbWrapperMock_, open(device, _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle), Return(0)));
 
         IAccessoryModeQueryChain::Promise::Pointer queryChainPromise;
         EXPECT_CALL(queryChainMock_, start(deviceHandle, _)).WillRepeatedly(SaveArg<1>(&queryChainPromise));
@@ -160,7 +160,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_NoAOAPCapableDevice, Conn
 
 BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_GetDeviceListFailed, ConnectedAccessoriesEnumeratorUnitTest)
 {
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(-1)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(-1)));
     EXPECT_CALL(promiseHandlerMock_, onResolve(_)).Times(0);
     EXPECT_CALL(promiseHandlerMock_, onReject(error::Error(error::ErrorCode::USB_LIST_DEVICES)));
 
@@ -172,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_GetDeviceListFailed, Conn
 
 BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_EmptyDevicesList, ConnectedAccessoriesEnumeratorUnitTest)
 {
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
     EXPECT_CALL(promiseHandlerMock_, onResolve(false));
     EXPECT_CALL(promiseHandlerMock_, onReject(_)).Times(0);
 
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_OpenDeviceFailed, Connect
         deviceList_.push_back(reinterpret_cast<libusb_device*>(i));
     }
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
 
     auto connectedAccessoriesEnumerator(std::make_shared<ConnectedAccessoriesEnumerator>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     connectedAccessoriesEnumerator->enumerate(std::move(promise_));
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_OpenDeviceFailed, Connect
 
     for(const auto& device : deviceList_)
     {
-        EXPECT_CALL(usbWrapperMock_, open(device, _)).WillOnce(DoAll(SetArgReferee<1>(nullptr), Return(0xFFF)));
+        EXPECT_CALL(usbWrapperMock_, open(device, _)).WillOnce(testing::DoAll(SetArgReferee<1>(nullptr), Return(0xFFF)));
     }
 
     ioService_.run();
@@ -211,10 +211,10 @@ BOOST_FIXTURE_TEST_CASE(ConnectedAccessoriesEnumerator_CancelEnumeration, Connec
     EXPECT_CALL(queryChainFactoryMock_, create()).WillOnce(Return(queryChain_));
     auto connectedAccessoriesEnumerator(std::make_shared<ConnectedAccessoriesEnumerator>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceList(_)).WillOnce(testing::DoAll(SetArgReferee<0>(deviceListHandle_), Return(0)));
     connectedAccessoriesEnumerator->enumerate(std::move(promise_));
 
-    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(*deviceList_.begin(), _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
 
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise;
     EXPECT_CALL(queryChainMock_, start(deviceHandle_, _)).WillOnce(SaveArg<1>(&queryChainPromise));

--- a/src/USB/USBEndpoint.ut.cpp
+++ b/src/USB/USBEndpoint.ut.cpp
@@ -142,7 +142,7 @@ BOOST_FIXTURE_TEST_CASE(USBEndpoint_BulkTransfer, USBEndpointUnitTest)
     common::Data data(1000, 0);
     common::DataBuffer buffer(data);
     EXPECT_CALL(usbWrapperMock_, fillBulkTransfer(&transfer, _, endpointAddress, buffer.data, buffer.size, _, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
     EXPECT_CALL(usbWrapperMock_, submitTransfer(&transfer));
 
     usbEndpoint->bulkTransfer(common::DataBuffer(data), 0, std::move(promise_));
@@ -180,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(USBEndpoint_MultipleBulkTransfers, USBEndpointUnitTest)
         common::Data data(10000 + attemptsCount, 0);
         common::DataBuffer buffer(data);
         EXPECT_CALL(usbWrapperMock_, fillBulkTransfer(&transfer, _, endpointAddress, buffer.data, buffer.size, _, _, _))
-                .WillOnce(DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
+                .WillOnce(testing::DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
         EXPECT_CALL(promiseHandlerMock_, onResolve(buffer.size)).Times(1);
 
         transfer.actual_length = 0;
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(USBEndpoint_ControlTransfer, USBEndpointUnitTest)
     common::Data data(100, 0);
     common::DataBuffer buffer(data);
     EXPECT_CALL(usbWrapperMock_, fillControlTransfer(&transfer, _, buffer.data, _, _, _))
-            .WillOnce(DoAll(SaveArg<3>(&transferCallback), SaveArg<4>(&transfer.user_data)));
+            .WillOnce(testing::DoAll(SaveArg<3>(&transferCallback), SaveArg<4>(&transfer.user_data)));
     EXPECT_CALL(usbWrapperMock_, submitTransfer(&transfer));
 
     usbEndpoint->controlTransfer(common::DataBuffer(data), 0, std::move(promise_));
@@ -242,7 +242,7 @@ BOOST_FIXTURE_TEST_CASE(USBEndpoint_InterruptTransfer, USBEndpointUnitTest)
     common::Data data(150, 0);
     common::DataBuffer buffer(data);
     EXPECT_CALL(usbWrapperMock_, fillInterruptTransfer(&transfer, _, endpointAddress, buffer.data, buffer.size, _, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
     EXPECT_CALL(usbWrapperMock_, submitTransfer(&transfer));
 
     usbEndpoint->interruptTransfer(common::DataBuffer(data), 0, std::move(promise_));
@@ -271,7 +271,7 @@ BOOST_FIXTURE_TEST_CASE(USBEndpoint_BulkTransferFailed, USBEndpointUnitTest)
     common::Data data(10, 0);
     common::DataBuffer buffer(data);
     EXPECT_CALL(usbWrapperMock_, fillBulkTransfer(&transfer, _, endpointAddress, buffer.data, buffer.size, _, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&transferCallback), SaveArg<6>(&transfer.user_data)));
     EXPECT_CALL(usbWrapperMock_, submitTransfer(&transfer));
 
     usbEndpoint->bulkTransfer(common::DataBuffer(data), 0, std::move(promise_));

--- a/src/USB/USBHub.cpp
+++ b/src/USB/USBHub.cpp
@@ -125,9 +125,12 @@ void USBHub::handleDevice(libusb_device* device)
     }
     else
     {
+
+#ifdef ENABLE_VMWARE_WORKAROUND
         ////////// Workaround for VMware
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         //////////
+#endif
 
         queryChainQueue_.emplace_back(queryChainFactory_.create());
 

--- a/src/USB/USBHub.ut.cpp
+++ b/src/USB/USBHub.ut.cpp
@@ -77,7 +77,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_QueryDevice, USBHubUnitTest)
     EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
 
     USBHub::Pointer usbHub(std::make_shared<USBHub>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     usbHub->start(std::move(promise_));
@@ -89,8 +89,8 @@ BOOST_FIXTURE_TEST_CASE(USBHub_QueryDevice, USBHubUnitTest)
     connectedDeviceDescriptor.idVendor = 123;
     connectedDeviceDescriptor.idProduct = 456;
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
-    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
     EXPECT_CALL(queryChainFactoryMock_, create()).WillOnce(Return(queryChain_));
 
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise;
@@ -113,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_AOAPDeviceConnected, USBHubUnitTest)
     EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
 
     USBHub::Pointer usbHub(std::make_shared<USBHub>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     usbHub->start(std::move(promise_));
@@ -125,8 +125,8 @@ BOOST_FIXTURE_TEST_CASE(USBHub_AOAPDeviceConnected, USBHubUnitTest)
     connectedDeviceDescriptor.idVendor = cGoogleVendorId;
     connectedDeviceDescriptor.idProduct = cAOAPWithAdbId;
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
-    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
     EXPECT_CALL(promiseHandlerMock_, onResolve(deviceHandle_));
     EXPECT_CALL(promiseHandlerMock_, onReject(_)).Times(0);
 
@@ -144,7 +144,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_GetDeviceDescriptorFailed, USBHubUnitTest)
     EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
 
     USBHub::Pointer usbHub(std::make_shared<USBHub>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     usbHub->start(std::move(promise_));
@@ -153,7 +153,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_GetDeviceDescriptorFailed, USBHubUnitTest)
     ioService_.reset();
 
     libusb_device_descriptor connectedDeviceDescriptor = {0};
-    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(1)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(1)));
 
     hotplugCallback_(nullptr, device_, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, userData);
     ioService_.run();
@@ -171,7 +171,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_OpenDeviceFailed, USBHubUnitTest)
     EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
 
     USBHub::Pointer usbHub(std::make_shared<USBHub>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     usbHub->start(std::move(promise_));
@@ -180,8 +180,8 @@ BOOST_FIXTURE_TEST_CASE(USBHub_OpenDeviceFailed, USBHubUnitTest)
     ioService_.reset();
 
     libusb_device_descriptor connectedDeviceDescriptor = {0};
-    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
-    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(DoAll(SetArgReferee<1>(deviceHandle_), Return(1)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(device_, _)).WillOnce(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(1)));
 
     hotplugCallback_(nullptr, device_, LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, userData);
     ioService_.run();
@@ -199,7 +199,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_CancelAllQueryChains, USBHubUnitTest)
     EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
-            .WillOnce(DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
+            .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
 
     USBHub::Pointer usbHub(std::make_shared<USBHub>(usbWrapperMock_, ioService_, queryChainFactoryMock_));
     usbHub->start(std::move(promise_));
@@ -211,8 +211,8 @@ BOOST_FIXTURE_TEST_CASE(USBHub_CancelAllQueryChains, USBHubUnitTest)
     connectedDeviceDescriptor.idVendor = 123;
     connectedDeviceDescriptor.idProduct = 456;
 
-    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).Times(2).WillRepeatedly(DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
-    EXPECT_CALL(usbWrapperMock_, open(device_, _)).Times(2).WillRepeatedly(DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, getDeviceDescriptor(device_, _)).Times(2).WillRepeatedly(testing::DoAll(SetArgReferee<1>(connectedDeviceDescriptor), Return(0)));
+    EXPECT_CALL(usbWrapperMock_, open(device_, _)).Times(2).WillRepeatedly(testing::DoAll(SetArgReferee<1>(deviceHandle_), Return(0)));
     EXPECT_CALL(queryChainFactoryMock_, create()).Times(2).WillRepeatedly(Return(queryChain_));
 
     IAccessoryModeQueryChain::Promise::Pointer queryChainPromise[2];

--- a/src/USB/USBHub.ut.cpp
+++ b/src/USB/USBHub.ut.cpp
@@ -63,7 +63,7 @@ protected:
     USBHubPromiseHandlerMock promiseHandlerMock_;
     IUSBHub::Promise::Pointer promise_;
     libusb_hotplug_callback_handle rawHotplugCallbacHandle_;
-    HotplugCallbackHandle hotplugCallbackHandle_;
+    HotPlugCallbackHandle hotplugCallbackHandle_;
     libusb_hotplug_callback_fn hotplugCallback_;
 
     static constexpr uint16_t cGoogleVendorId = 0x18D1;

--- a/src/USB/USBHub.ut.cpp
+++ b/src/USB/USBHub.ut.cpp
@@ -74,7 +74,7 @@ protected:
 BOOST_FIXTURE_TEST_CASE(USBHub_QueryDevice, USBHubUnitTest)
 {
     void* userData = nullptr;
-    EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
+    EXPECT_CALL(usbWrapperMock_, hotPlugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
             .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
@@ -110,7 +110,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_QueryDevice, USBHubUnitTest)
 BOOST_FIXTURE_TEST_CASE(USBHub_AOAPDeviceConnected, USBHubUnitTest)
 {
     void* userData = nullptr;
-    EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
+    EXPECT_CALL(usbWrapperMock_, hotPlugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
             .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
@@ -141,7 +141,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_AOAPDeviceConnected, USBHubUnitTest)
 BOOST_FIXTURE_TEST_CASE(USBHub_GetDeviceDescriptorFailed, USBHubUnitTest)
 {
     void* userData = nullptr;
-    EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
+    EXPECT_CALL(usbWrapperMock_, hotPlugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
             .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
@@ -168,7 +168,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_GetDeviceDescriptorFailed, USBHubUnitTest)
 BOOST_FIXTURE_TEST_CASE(USBHub_OpenDeviceFailed, USBHubUnitTest)
 {
     void* userData = nullptr;
-    EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
+    EXPECT_CALL(usbWrapperMock_, hotPlugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
             .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));
@@ -196,7 +196,7 @@ BOOST_FIXTURE_TEST_CASE(USBHub_OpenDeviceFailed, USBHubUnitTest)
 BOOST_FIXTURE_TEST_CASE(USBHub_CancelAllQueryChains, USBHubUnitTest)
 {
     void* userData = nullptr;
-    EXPECT_CALL(usbWrapperMock_, hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
+    EXPECT_CALL(usbWrapperMock_, hotPlugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                          LIBUSB_HOTPLUG_MATCH_ANY, _, _))
             .WillOnce(testing::DoAll(SaveArg<5>(&hotplugCallback_), SaveArg<6>(&userData), Return(hotplugCallbackHandle_)));

--- a/src/USB/USBWrapper.cpp
+++ b/src/USB/USBWrapper.cpp
@@ -153,13 +153,13 @@ void USBWrapper::handleEvents()
     libusb_handle_events(usbContext_);
 }
 
-HotplugCallbackHandle USBWrapper::hotplugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
+HotPlugCallbackHandle USBWrapper::hotPlugRegisterCallback(libusb_hotplug_event events, libusb_hotplug_flag flags, int vendor_id, int product_id, int dev_class,
                                                           libusb_hotplug_callback_fn cb_fn, void *user_data)
 {
     libusb_hotplug_callback_handle raw_handle;
     libusb_hotplug_register_callback (usbContext_, events, flags, vendor_id, product_id, dev_class, cb_fn, user_data, &raw_handle);
 
-    HotplugCallbackHandle handle(&raw_handle, [this](auto raw_handle) { libusb_hotplug_deregister_callback(usbContext_, *raw_handle); });
+    HotPlugCallbackHandle handle(&raw_handle, [this](auto raw_handle) { libusb_hotplug_deregister_callback(usbContext_, *raw_handle); });
     return handle;
 }
 


### PR DESCRIPTION
Changes for Boost 1.71
Changes for current googletest
Simplify googletest cmake
Makes included libraries explicit

aasdk_ut passes