### PR TITLE
[fix] C cast for LIBUSB_HOTPLUG_NO_FLAGS in C++ avoiding an implicit ill formed cast

### DIFF
--- a/src/USB/USBHub.cpp
+++ b/src/USB/USBHub.cpp
@@ -50,7 +50,7 @@ void USBHub::start(Promise::Pointer promise)
         if(self_ == nullptr)
         {
             self_ = this->shared_from_this();
-            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, LIBUSB_HOTPLUG_NO_FLAGS, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
+            hotplugHandle_ = usbWrapper_.hotplugRegisterCallback(LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED, (libusb_hotplug_flag) LIBUSB_HOTPLUG_NO_FLAGS, LIBUSB_HOTPLUG_MATCH_ANY, LIBUSB_HOTPLUG_MATCH_ANY,
                                                                  LIBUSB_HOTPLUG_MATCH_ANY, reinterpret_cast<libusb_hotplug_callback_fn>(&USBHub::hotplugEventsHandler), reinterpret_cast<void*>(this));
         }
     });


### PR DESCRIPTION
At src/USB/USBHub.cpp:53

The LIBUSB_HOTPLUG_NO_FLAGS macro is a define with value 0, which can't be implicitly casted in C++
I recommend just doing (libusb_hotplug_flag) LIBUSB_HOTPLUG_NO_FLAGS  for this very line